### PR TITLE
fix(requirements_gpu): use PyTorch CUDA 12.9 index; remove +cu129 local tags

### DIFF
--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,8 +1,9 @@
---extra-index-url https://download.pytorch.org/whl/cu129
+--index-url https://download.pytorch.org/whl/cu129
+--extra-index-url https://pypi.org/simple
 
-torch==2.8.0+cu129
-torchvision==0.23.0+cu129
-torchaudio==2.8.0+cu129
+torch==2.8.0
+torchvision==0.23.0
+torchaudio==2.8.0
 
 aiofiles==24.1.0
 aiohttp==3.12.15


### PR DESCRIPTION
Problem: Installing torch==2.8.0+cu129 via various PyPI mirrors fails because mirrors don't host the local-tagged CUDA wheels.

Changes:
- Set https://download.pytorch.org/whl/cu129 as primary --index-url and keep https://pypi.org/simple as --extra-index-url.
- Drop "+cu129" local tags from torch/torchvision/torchaudio so pip resolves the official CUDA 12.9 wheels from the PyTorch index.

Impact:
- Ensures reliable GPU setup across environments using mirrors.
- Non-PyTorch deps continue to resolve via PyPI.

Verification:
- Windows (Python 3.12) with CUDA 12.9-capable drivers: torch 2.8.0+cu129 installs; torch.version.cuda == 12.9; torch.cuda.is_available() == True.

Notes:
- xformers==0.0.32.post2 remains pinned and is available from the CUDA 12.9 index.
- If an installer enforces third-party mirrors, users can force install with:
  pip install --index-url https://download.pytorch.org/whl/cu129 torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU package dependencies configuration for improved package resolution.
  * Updated torch, torchvision, and torchaudio to the latest versions for GPU environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->