### PR TITLE
fix: dynamic bubble mask erosion to prevent border loss and color shifts

### DIFF
--- a/manga_translator/mask_refinement/__init__.py
+++ b/manga_translator/mask_refinement/__init__.py
@@ -26,7 +26,11 @@ def _erode_bubble_mask(bubble_mask: np.ndarray) -> np.ndarray:
     kernel_size = 2 * erode_px + 1
     erode_kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
     logger.info(f"Bubble mask erosion: image={w}x{h}, erode_px={erode_px}")
-    return cv2.erode(bubble_mask, erode_kernel, iterations=1)
+    eroded = cv2.erode(bubble_mask, erode_kernel, iterations=1)
+    if np.count_nonzero(eroded) == 0:
+        logger.warning("Bubble mask fully eroded; falling back to original mask")
+        return bubble_mask
+    return eroded
 
 
 def _build_model_bubble_mask(image_shape: Tuple[int, int], result: Any) -> Tuple[np.ndarray, str]:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p node="[object Object]" style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1.3em 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; white-space: pre-wrap; line-height: 1.6; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Problem:</strong></p><ol style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1em 0px; padding: 0px 0px 0px 1.5em; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); list-style: decimal; -webkit-tap-highlight-color: transparent; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-weight: normal; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px 0px 0.5em; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Border Erasure:</strong><span> </span>Static masks often caused the inpainting model to blur or partially erase the black borders of speech bubbles.</li><li style="box-sizing: border-box; font-weight: normal; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px 0px 0.5em; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Color Discoloration:</strong><span> </span>When the mask is too close to the border, the inpainting model tends to "bleed" the black border color into the bubble's interior, causing gray smudges or inconsistent white tones.</li></ol><p node="[object Object]" style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1.3em 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; white-space: pre-wrap; line-height: 1.6; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Solution:</strong>
Implemented a resolution-aware dynamic erosion for the bubble segmentation mask. By shrinking the mask slightly inward before inpainting, we provide a "buffer zone" that preserves the original border and prevents color bleeding.</p><p node="[object Object]" style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1.3em 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; white-space: pre-wrap; line-height: 1.6; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Erosion Logic:</strong>
The erosion size is now dynamically calculated as <strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">1% of the image's shorter side</strong>, clamped between <strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">3px and 30px</strong>.</p><div class="sc-ctAsvE kmLLKP table-wrapper" style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; position: relative; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Shorter Side (px) | Erosion Size (px) | Status
-- | -- | --
≤ 300px | 3px | Minimum (Floor)
1000px | 10px | 1% calculation
2000px | 20px | 1% calculation
≥ 3000px | 30px | Maximum (Ceiling)

<div class="sc-eZSpzM dPkgxW table-toolbar" style="box-sizing: border-box; font-weight: normal; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; position: absolute; top: 8px; right: 8px; z-index: 10; display: flex; gap: 4px; border-radius: 4px; opacity: 0; transition: opacity 0.2s; transform: translateZ(0px); will-change: opacity;"></div></div><p node="[object Object]" style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1.3em 0px 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent; white-space: pre-wrap; line-height: 1.6; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Key Benefits:</strong></p><ul style="box-sizing: border-box; font-weight: 400; border: 0px solid oklch(0.92 0.004 286.32); margin: 1em 0px; padding: 0px 0px 0px 1.5em; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); list-style: initial; -webkit-tap-highlight-color: transparent; color: rgb(0, 0, 0); font-family: &quot;&quot;, &quot;Twemoji Country Flags&quot;, Ubuntu, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, Roboto, Oxygen, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-weight: normal; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px 0px 0.5em; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Cleaner Borders:</strong><span> </span>Keeps the original hand-drawn or digital borders intact.</li><li style="box-sizing: border-box; font-weight: normal; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px 0px 0.5em; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;"><strong style="box-sizing: border-box; font-weight: bold; border: 0px solid oklch(0.92 0.004 286.32); margin: 0px; padding: 0px; outline-color: oklab(0.705 0.00415142 -0.0144141 / 0.5); -webkit-tap-highlight-color: transparent;">Color Consistency:</strong><span> </span>Prevents the inpainting model from sampling border pixels, ensuring the bubble interior remains a clean, consistent color.</li></ul><!--EndFragment-->
</body>
</html>
Formula:
erosion_px = clamp(shorter_side * 0.01, 3, 30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text bubble and box mask precision using adaptive erosion to reduce unwanted boundary leakage and produce cleaner detections.
  * Enhanced handling for very small or empty masks to avoid losing valid regions, improving translation accuracy for tight or compact text bubbles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->