### PR TITLE
fix: 竖排文本时将波浪号旋转 90 度

### DIFF
--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -43,7 +43,7 @@ _VERTICAL_ALIGN_BOTTOM_LEFT = {'﹂', '﹄'}
 _VERTICAL_ALIGN_TOP_CENTER = {'︵', '︷', '︹', '︻', '︽', '︿', '﹇'}
 _VERTICAL_ALIGN_BOTTOM_CENTER = {'︶', '︸', '︺', '︼', '︾', '﹀', '﹈'}
 
-_VERTICAL_ROTATE_90 = {'ー', '~', '〜', '～'}
+_VERTICAL_ROTATE_90 = {'ー', '~', '〜', '～', '_', '—', '–', '-', '−', '‥'}
 
 _QT_FONT_PROBE_SIZE = 32.0
 _thread_state = threading.local()

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -43,6 +43,8 @@ _VERTICAL_ALIGN_BOTTOM_LEFT = {'﹂', '﹄'}
 _VERTICAL_ALIGN_TOP_CENTER = {'︵', '︷', '︹', '︻', '︽', '︿', '﹇'}
 _VERTICAL_ALIGN_BOTTOM_CENTER = {'︶', '︸', '︺', '︼', '︾', '﹀', '﹈'}
 
+_VERTICAL_ROTATE_90 = {'ー', '~', '〜', '～'}
+
 _QT_FONT_PROBE_SIZE = 32.0
 _thread_state = threading.local()
 _qt_runtime_lock = threading.Lock()
@@ -99,8 +101,8 @@ class FontState:
 
 def CJK_Compatibility_Forms_translate(cdpt: str, direction: int):
     """渲染层不再做字符替换，全部交给翻译后处理阶段。"""
-    if cdpt == 'ー' and direction == 1:
-        return 'ー', 90
+    if direction == 1 and cdpt in _VERTICAL_ROTATE_90:
+        return cdpt, 90
     return cdpt, 0
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical text rendering by expanding which punctuation and vowel-like marks are rotated 90°. Tildes, various dashes, underscores and similar marks now orient correctly in vertical layouts, improving visual accuracy and readability for vertical manga text and other vertical text displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgmzhn/manga-translator-ui/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->