### PR TITLE
feat(packaging): add automatic HSA override and VRAM optimize tips for AMD APUs

### DIFF
--- a/packaging/launch.py
+++ b/packaging/launch.py
@@ -18,6 +18,9 @@ VERSION = '1.7.6'
 PYTHON_VERSION_MIN = (3, 12)
 PYTHON_VERSION_MAX = (3, 12)  # 仅支持Python 3.12,不支持3.13+
 
+# AMD APU HSA 架构伪装版本 (针对不支持的 gfx1103/gfx1150 核显)
+HSA_APU_JAILBREAK_VERSION = '11.0.0'
+
 # 路径配置
 PATH_ROOT = Path(__file__).parent.parent
 stored_commit_hash = None
@@ -1475,14 +1478,14 @@ except:
                 
         if target_gfx in ['gfx1103', 'gfx1150']:
             print('\n[INFO] 检测到 AMD APU 核显 (780M/890M等)')
-            print('       正在自动注入架构越狱环境变量: HSA_OVERRIDE_GFX_VERSION=11.0.0 以启用核显加速...')
+            print(f'       正在自动注入架构越狱环境变量: HSA_OVERRIDE_GFX_VERSION={HSA_APU_JAILBREAK_VERSION} 以启用核显加速...')
             print('       [提示] 核显显存优化建议:')
             print('              由于 AMD 核显共享内存机制，若您的 BIOS 预分配显存过低（如 512MB），')
             print('              运行本地模型时极易遭遇 "Out of Memory" 报错或卡顿。')
             print('              💡 建议：进入您的电脑 BIOS 或品牌控制软件，')
             print('              将 "UMA Frame Buffer Size" (预分配显存) 修改为 4G、8G 或更高，')
             print('              以获得最稳定、最流畅的核显加速体验！\n')
-            os.environ['HSA_OVERRIDE_GFX_VERSION'] = '11.0.0'
+            os.environ['HSA_OVERRIDE_GFX_VERSION'] = HSA_APU_JAILBREAK_VERSION
 
     # 返回 AMD PyTorch 相关信息
     return use_amd_pytorch, amd_gfx_version

--- a/packaging/launch.py
+++ b/packaging/launch.py
@@ -751,6 +751,20 @@ def detect_amd_gfx_version(gpu_name):
             'name': 'RDNA 4 (RX 9060/9070 系列)',
             'has_torch': True
         },
+
+        # RDNA 3 APU 核显 - 官方不支持但可越狱加速
+        'gfx1103': {
+            'keywords': ['780M', '760M', '740M'],
+            'name': 'RDNA 3 APU (Radeon 780M / 760M / 740M) - 越狱加速',
+            'has_torch': False
+        },
+
+        # RDNA 3.5 APU 核显 - 官方不支持但可越狱加速
+        'gfx1150': {
+            'keywords': ['890M', '880M', '860M'],
+            'name': 'RDNA 3.5 APU (Radeon 890M / 880M / 860M) - 越狱加速',
+            'has_torch': False
+        },
         
         # 以下架构不支持 torch（已验证）
         # RDNA 2 架构 (RX 6000 系列) - 不支持
@@ -1449,6 +1463,27 @@ except:
     else:
         print(f'依赖已满足 ✓')
     
+    # 自动设置 AMD APU 越狱环境变量 (HSA Override)
+    if use_amd_pytorch:
+        target_gfx = amd_gfx_version
+        if not target_gfx and gpu_name:
+            name_upper = gpu_name.upper()
+            if any(kw in name_upper for kw in ['780M', '760M', '740M']):
+                target_gfx = 'gfx1103'
+            elif any(kw in name_upper for kw in ['890M', '880M', '860M']):
+                target_gfx = 'gfx1150'
+                
+        if target_gfx in ['gfx1103', 'gfx1150']:
+            print('\n[INFO] 检测到 AMD APU 核显 (780M/890M等)')
+            print('       正在自动注入架构越狱环境变量: HSA_OVERRIDE_GFX_VERSION=11.0.0 以启用核显加速...')
+            print('       [提示] 核显显存优化建议:')
+            print('              由于 AMD 核显共享内存机制，若您的 BIOS 预分配显存过低（如 512MB），')
+            print('              运行本地模型时极易遭遇 "Out of Memory" 报错或卡顿。')
+            print('              💡 建议：进入您的电脑 BIOS 或品牌控制软件，')
+            print('              将 "UMA Frame Buffer Size" (预分配显存) 修改为 4G、8G 或更高，')
+            print('              以获得最稳定、最流畅的核显加速体验！\n')
+            os.environ['HSA_OVERRIDE_GFX_VERSION'] = '11.0.0'
+
     # 返回 AMD PyTorch 相关信息
     return use_amd_pytorch, amd_gfx_version
 


### PR DESCRIPTION
### 🚀 背景与功能 (Background & Feature)
在目前主流的搭载 AMD 移动 CPU/APU 的设备（如 780M / 880M / 890M 核显设备）上，由于 Windows 平台的 ROCm PyTorch 编译版没有原生编译这些 APU 核显架构微码，运行本地模型时极易发生驱动不识别闪退或退回 CPU 极慢运行的情况。

本 PR 旨在**零配置自动激活这些 RDNA 3 / RDNA 3.5 APU 的硬件加速**，并给出专业的显存配置指导：

1. **精确 APU 微架构映射 (APU Micro-arch Mapping)**
   * 在 `detect_amd_gfx_version` 的显卡列表里明确加入了 **`gfx1103`** (RDNA3 APU: Radeon 780M/760M/740M) 与 **`gfx1150`** (RDNA3.5 APU: Radeon 890M/880M/860M) 两个核显编译目标的识别，与已原生支持的 Strix Halo (`gfx1151`) 进行概念分离。
2. **零配置内存直通越狱 (Zero-config HSA Override)**
   * 当确定使用 AMD 版本且检测到上述显卡时，自检脚本会在当前进程自动注入环境变量 `HSA_OVERRIDE_GFX_VERSION=11.0.0` 进行架构欺骗直通。
   * 启动后拉起的 GUI 主进程会直接继承此变量，**用户无需做任何手动 `.bat` 设置即可享受开箱即用的核显 GPU 加速！**
3. **核显显存优化建议 (VRAM Optimization Tip)**
   * 在终端控制台输出中贴心地增加了由于 WDDM 内存共享引起的 BIOS 预分配显存（UMA Frame Buffer Size）调整建议，帮助核显用户规避 OOM 崩溃并极大限度优化运行效能。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended AMD APU integrated GPU support for additional Radeon models: 780M, 760M, 740M, 890M, 880M, and 860M
  * Automatic compatibility workaround applied during AMD PyTorch install/use for affected APU systems
  * Displays UMA frame buffer size guidance and tuning suggestions for kernel iGPU acceleration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgmzhn/manga-translator-ui/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->