### PR TITLE
fix: 仅对已有修复图的页面做防黑闪

### DIFF
--- a/desktop_qt_ui/editor/controller_document_service.py
+++ b/desktop_qt_ui/editor/controller_document_service.py
@@ -207,8 +207,9 @@ class EditorControllerDocumentService:
         )
 
     def do_load_image(self, image_path: str) -> None:
-        # 切图:保留旧画面 + 旧 LRU 缓存,等新数据信号到达再覆盖,避免黑闪
-        self.clear_editor_state(keep_document=True)
+        # 防黑闪:仅对有修复图的页保留旧画面,无修复图时需立即刷新避免蒙版画在旧原图上
+        has_inpainted = bool(find_inpainted_path(image_path))
+        self.clear_editor_state(keep_document=has_inpainted)
 
         toast_manager = self.controller.get_toast_manager()
         if toast_manager is not None:


### PR DESCRIPTION
切页时 keep_document=True 会保留旧页面画面以避免黑闪。但对于尚未生成修复图（inpainted）的页面（有蒙版但未跑完去字流程），旧原图残留导致新蒙版画在旧原图上，产生错误的混合显示。

修复：切页前检查目标页面是否有 inpainted 文件。仅对已有修复图的页面使用 keep_document=True（防黑闪）；无修复图的页面直接刷新底图。

修复页面 13、14、17 在切换时显示为"旧原图 + 新蒙版"的问题。