### PR TITLE
Fix line spacing calculation for multipliers < 1.0 (#187)

### DIFF
--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -761,12 +761,11 @@ def _normalize_line_spacing(line_spacing: float) -> float:
 
 
 def resolve_horizontal_line_spacing_multiplier(line_spacing: float) -> float:
-    value = _normalize_line_spacing(line_spacing)
-    return 1.0 + (value - 1.0) * 10.0 if value > 1.0 else value
-
+    return _normalize_line_spacing(line_spacing)
 
 def calc_horizontal_line_spacing_px(font_size: int, line_spacing: float) -> int:
-    return int(font_size * 0.01 * resolve_horizontal_line_spacing_multiplier(line_spacing))
+    value = _normalize_line_spacing(line_spacing)
+    return int(font_size * (value - 1.0))
 
 
 def _scale_advance(advance: int, letter_spacing: float) -> int:
@@ -1285,7 +1284,12 @@ def put_text_vertical(
     _ = (h, region_count)
     stroke_ratio = _resolve_stroke_ratio(config, stroke_width)
     bg_size = int(max(font_size * stroke_ratio, 1)) if bg is not None else 0
-    spacing_x = int(font_size * 0.2 * (_normalize_line_spacing(line_spacing) or 1.0))
+    
+    val_ls = _normalize_line_spacing(line_spacing)
+    if val_ls >= 1.0:
+        spacing_x = int(font_size * 0.2 * val_ls)
+    else:
+        spacing_x = int(font_size * (val_ls - 0.8))
     block_cache = {}
     stage_t0 = perf_counter() if profile_stats is not None else None
     layouts = [


### PR DESCRIPTION
Fixes #187. Adjusted the line spacing logic so that values less than 1.0 correctly reduce line spacing by yielding a negative gap, instead of always clamping the additional spacing near zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined horizontal line spacing to use consistent, normalized spacing values for more predictable text rendering.
  * Improved vertical layout by adjusting inter-column horizontal spacing differently for smaller versus at/above-default spacing values, resulting in cleaner text flow and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->