### PR TITLE
fix(ui): 修复编辑器属性面板滚轮误触导致参数被意外修改的问题

### DIFF
--- a/desktop_qt_ui/ui/widgets/property_panel.py
+++ b/desktop_qt_ui/ui/widgets/property_panel.py
@@ -134,6 +134,12 @@ class PropertyPanel(QWidget):
         self.block_updates = False
         self.current_region_index = -1
         self.clear_and_disable_selection_dependent()
+        
+        # 仅为上面容易产生严重副作用的下拉框安装滚轮防误触，保留样式设置里的滚轮调节功能
+        from ui.widgets.wheel_filter import install_wheel_filter
+        install_wheel_filter(self.ocr_model_combo)
+        install_wheel_filter(self.translator_combo)
+        install_wheel_filter(self.target_language_combo)
     
     def _t(self, key: str, **kwargs) -> str:
         """翻译辅助方法"""

--- a/desktop_qt_ui/ui/widgets/wheel_filter.py
+++ b/desktop_qt_ui/ui/widgets/wheel_filter.py
@@ -4,7 +4,7 @@
 """
 
 from PyQt6.QtCore import QEvent, QObject
-from PyQt6.QtWidgets import QComboBox, QDoubleSpinBox, QSpinBox
+from PyQt6.QtWidgets import QComboBox, QDoubleSpinBox, QSpinBox, QSlider
 
 
 class NoWheelComboBox(QComboBox):
@@ -28,9 +28,19 @@ class WheelEventFilter(QObject):
         """
         if event.type() == QEvent.Type.Wheel:
             # 检查是否是需要特殊处理的控件
-            if isinstance(obj, (QComboBox, QSpinBox, QDoubleSpinBox)):
+            if isinstance(obj, (QComboBox, QSpinBox, QDoubleSpinBox, QSlider)):
                 # 完全忽略滚轮事件，无论是否有焦点
                 event.ignore()
+                
+                # 手动向上冒泡，确保 QScrollArea 等父容器能够接收到滚动事件
+                from PyQt6.QtWidgets import QApplication
+                parent = obj.parentWidget()
+                while parent:
+                    QApplication.sendEvent(parent, event)
+                    if event.isAccepted():
+                        break
+                    parent = parent.parentWidget()
+                
                 return True
         
         # 继续正常处理其他事件
@@ -48,7 +58,7 @@ def install_wheel_filter(widget):
     
     # 递归为所有子控件安装过滤器
     def install_recursive(w):
-        if isinstance(w, (QComboBox, QSpinBox, QDoubleSpinBox)):
+        if isinstance(w, (QComboBox, QSpinBox, QDoubleSpinBox, QSlider)):
             w.installEventFilter(wheel_filter)
             # 禁用控件的焦点策略为滚轮焦点
             w.setFocusPolicy(w.focusPolicy() & ~0x0008)  # 移除 WheelFocus
@@ -63,6 +73,10 @@ def install_wheel_filter(widget):
             child.setFocusPolicy(child.focusPolicy() & ~0x0008)
         
         for child in w.findChildren(QDoubleSpinBox):
+            child.installEventFilter(wheel_filter)
+            child.setFocusPolicy(child.focusPolicy() & ~0x0008)
+
+        for child in w.findChildren(QSlider):
             child.installEventFilter(wheel_filter)
             child.setFocusPolicy(child.focusPolicy() & ~0x0008)
     


### PR DESCRIPTION
仅针对OCR模型、翻译器、目标语言开启防误触保护，保留下方样式设置面板（如滑块、字间距等）原有的滚轮快速调整功能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental mouse-wheel changes in property panel drop-downs, reducing unintended selection changes.
  * Extended wheel-event protection to sliders, so scrolling over them no longer alters values unintentionally.
  * Improved wheel-event forwarding and focus handling for affected controls, keeping scroll behavior more consistent within scrollable areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->