### PR TITLE
docs: add Linux ROCm PyTorch install step for AMD source installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ docker run -d --name manga-translator -p 8000:8000 hgmzhn/manga-translator:lates
    pip install -r requirements_gpu.txt
    
    # AMD GPU（仅 RX 7000/9000 系列）
+   # Linux 需先装 ROCm 版 PyTorch（requirements_amd.txt 不含 torch，Windows 由安装脚本单独装）
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm7.2
    pip install -r requirements_amd.txt
    
    # CPU 版本

--- a/README_EN.md
+++ b/README_EN.md
@@ -197,6 +197,9 @@ Best for developers or users who want full customization.
    pip install -r requirements_gpu.txt
 
    # AMD GPU (RX 7000 / 9000 only)
+   # On Linux, install the ROCm PyTorch build first (requirements_amd.txt has no torch;
+   # the Windows install script installs it separately)
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm7.2
    pip install -r requirements_amd.txt
 
    # CPU build


### PR DESCRIPTION
The "Run from Source → AMD GPU" steps only run `pip install -r requirements_amd.txt`, but that file doesn't include torch — on Windows the install script installs the ROCm PyTorch separately, so on Linux the source install leaves you without PyTorch. This adds the Linux ROCm PyTorch step (official PyTorch ROCm 7.2 index) before `requirements_amd.txt`, in both README.md and README_EN.md.

Tested on AMD Radeon 8060S / Ryzen AI Max+ 395 (Strix Halo, gfx1151), Ubuntu 24.04, ROCm 7.2:
- `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm7.2` → torch 2.12.1+rocm7.2, `torch.cuda.is_available()` = True (AMD Radeon 8060S)
- `pip install -r requirements_amd.txt` completes cleanly (incl. pydensecrf built from source)
- `python -m manga_translator local -i <img>` runs the detection/OCR/inpaint GPU pipeline with no ROCm errors (only stops at the online-translation step without an API key)

gfx1151 is already in the supported list; this documents the Linux install path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified AMD GPU setup steps in the developer installation guides.
  * Added a Linux-specific note to install the ROCm PyTorch build before other requirements.
  * Included the recommended PyTorch install command for ROCm 7.2.
  * Updated the English guide to note that Windows installs PyTorch separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->