### PR TITLE
Update requirements_amd.txt

### DIFF
--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -102,7 +102,8 @@ scikit-image==0.25.2
 starlette==0.47.2
 tiktoken==0.11.0
 timm>=1.0.19
-transformers==4.55.0
+transformers==4.56.0
+#transformers 目前rocm官方版7.1-7.2 已知bug 需要大于4.55.0才能运行MTU, therock社区版 则不影响 所以统一升级4.56.0
 accelerate>=1.12.0
 tqdm==4.67.1
 unidic_lite==1.0.8


### PR DESCRIPTION
Update transformers version.
Fix when transformers <=4.55.5 in Window
show "No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package" bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI-related dependency to a newer version for improved compatibility.
  * Added a note clarifying version requirements for certain ROCm builds, helping avoid known runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->