### PR TITLE
Add Atlas Cloud OpenAI-compatible preset

### DIFF
--- a/desktop_qt_ui/services/preset_service.py
+++ b/desktop_qt_ui/services/preset_service.py
@@ -8,6 +8,9 @@ import os
 import sys
 from typing import Dict, List, Optional
 
+ATLAS_CLOUD_OPENAI_BASE = "https://api.atlascloud.ai/v1"
+ATLAS_CLOUD_TEXT_MODEL = "qwen/qwen3.5-flash"
+
 
 class PresetService:
     """预设管理服务"""
@@ -34,8 +37,8 @@ class PresetService:
         # 确保预设目录存在
         os.makedirs(self.presets_dir, exist_ok=True)
         
-        # 创建默认预设（如果不存在）
-        self._create_default_preset()
+        # 创建内置预设（如果不存在）
+        self._create_builtin_presets()
         
         self.logger.info(f"预设目录: {self.presets_dir}")
 
@@ -97,18 +100,34 @@ class PresetService:
         default_env["OPENAI_API_BASE"] = "https://api.openai.com/v1"
         default_env["OPENAI_MODEL"] = "gpt-4o"
         return default_env
+
+    def _build_atlascloud_preset_env(self) -> Dict[str, str]:
+        """构建 Atlas Cloud OpenAI-compatible 预设内容。"""
+        atlas_env = self._normalize_preset_env_vars({})
+        atlas_env["OPENAI_API_KEY"] = ""
+        atlas_env["OPENAI_API_BASE"] = ATLAS_CLOUD_OPENAI_BASE
+        atlas_env["OPENAI_MODEL"] = ATLAS_CLOUD_TEXT_MODEL
+        return atlas_env
+
+    def _write_builtin_preset_if_missing(self, preset_name: str, env_vars: Dict[str, str]):
+        preset_path = os.path.join(self.presets_dir, f"{preset_name}.json")
+        if os.path.exists(preset_path):
+            return
+        try:
+            with open(preset_path, 'w', encoding='utf-8') as f:
+                json.dump(env_vars, f, indent=2, ensure_ascii=False)
+            self.logger.info(f"已创建{preset_name}预设")
+        except Exception as e:
+            self.logger.error(f"创建{preset_name}预设失败: {e}")
+
+    def _create_builtin_presets(self):
+        """创建内置预设"""
+        self._write_builtin_preset_if_missing("默认", self._build_default_preset_env())
+        self._write_builtin_preset_if_missing("Atlas Cloud", self._build_atlascloud_preset_env())
     
     def _create_default_preset(self):
         """创建默认预设"""
-        default_preset_path = os.path.join(self.presets_dir, "默认.json")
-        if not os.path.exists(default_preset_path):
-            default_env = self._build_default_preset_env()
-            try:
-                with open(default_preset_path, 'w', encoding='utf-8') as f:
-                    json.dump(default_env, f, indent=2, ensure_ascii=False)
-                self.logger.info("已创建默认预设")
-            except Exception as e:
-                self.logger.error(f"创建默认预设失败: {e}")
+        self._write_builtin_preset_if_missing("默认", self._build_default_preset_env())
     
     def get_presets_list(self) -> List[str]:
         """获取所有预设名称列表"""

--- a/tests/test_preset_service.py
+++ b/tests/test_preset_service.py
@@ -1,0 +1,43 @@
+import json
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "desktop_qt_ui" / "services" / "preset_service.py"
+spec = importlib.util.spec_from_file_location("preset_service", MODULE_PATH)
+preset_service = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(preset_service)
+
+ATLAS_CLOUD_OPENAI_BASE = preset_service.ATLAS_CLOUD_OPENAI_BASE
+ATLAS_CLOUD_TEXT_MODEL = preset_service.ATLAS_CLOUD_TEXT_MODEL
+PresetService = preset_service.PresetService
+
+
+def test_builtin_presets_include_atlas_cloud_openai_compatible_config(tmp_path):
+    service = PresetService(presets_dir=str(tmp_path))
+
+    assert service.get_presets_list() == ["Atlas Cloud", "默认"]
+
+    atlas_preset = json.loads((tmp_path / "Atlas Cloud.json").read_text(encoding="utf-8"))
+
+    assert atlas_preset["OPENAI_API_KEY"] == ""
+    assert atlas_preset["OPENAI_API_BASE"] == ATLAS_CLOUD_OPENAI_BASE
+    assert atlas_preset["OPENAI_MODEL"] == ATLAS_CLOUD_TEXT_MODEL
+    assert atlas_preset["OCR_OPENAI_API_KEY"] == ""
+    assert atlas_preset["COLOR_OPENAI_API_KEY"] == ""
+    assert atlas_preset["RENDER_OPENAI_API_KEY"] == ""
+
+
+def test_builtin_presets_do_not_overwrite_user_customizations(tmp_path):
+    atlas_path = tmp_path / "Atlas Cloud.json"
+    atlas_path.write_text(
+        json.dumps({"OPENAI_API_KEY": "user-key", "OPENAI_API_BASE": "https://example.test/v1"}),
+        encoding="utf-8",
+    )
+
+    PresetService(presets_dir=str(tmp_path))
+
+    atlas_preset = json.loads(atlas_path.read_text(encoding="utf-8"))
+    assert atlas_preset == {
+        "OPENAI_API_KEY": "user-key",
+        "OPENAI_API_BASE": "https://example.test/v1",
+    }


### PR DESCRIPTION
## Summary
- add a built-in `Atlas Cloud` preset for the existing OpenAI-compatible translator configuration
- prefill `OPENAI_API_BASE` with `https://api.atlascloud.ai/v1` and `OPENAI_MODEL` with `qwen/qwen3.5-flash`
- keep `OPENAI_API_KEY` empty so users provide their own key
- add focused tests for preset creation and non-overwrite behavior

## Notes
This reuses the existing OpenAI-compatible path instead of adding a new translator enum. It does not change README files and does not add sponsor, logo, credits, or partner-promotion content.

## Validation
- `python3 -m pytest tests/test_preset_service.py -q`
- `python3 -m py_compile desktop_qt_ui/services/preset_service.py tests/test_preset_service.py`
- `git diff --check`
- live Atlas Cloud model catalog check confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in Atlas Cloud preset with OpenAI-compatible connection settings and a recommended text model.
  * The default preset and Atlas Cloud preset are created automatically when missing.

* **Bug Fixes**
  * Existing preset customizations are preserved and are not overwritten during startup.

* **Tests**
  * Added coverage verifying built-in preset creation and protection of user-customized settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->