### PR TITLE
fix: let the mask brush force a repair over already-repaired areas

### DIFF
--- a/desktop_qt_ui/editor/commands.py
+++ b/desktop_qt_ui/editor/commands.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import numpy as np
 from PyQt6.QtGui import QUndoCommand
 
+from .inpaint_state import INPAINT_BBOX_PADDING, InpaintArtifact
+
 if TYPE_CHECKING:
     from desktop_qt_ui.editor.editor_model import EditorModel
 
@@ -285,6 +287,113 @@ class MaskEditCommand(QUndoCommand):
 
     def undo(self):
         self._apply_mask(self._full_old_mask, self._old_patch)
+
+
+class BrushStrokeCommand(QUndoCommand):
+    """蒙版画笔笔画：蒙版补丁 + 修复图补丁合成一个撤销条目。
+
+    蒙版画笔不同于橡皮擦——它要求“已修复处再涂一次能继续修”，因此修复图不再是
+    f(底图, 蒙版) 的纯函数，撤销无法靠重算得到，只能像 PaintOverlayEditCommand
+    那样存像素。这里只存笔画包围盒（按 INPAINT_BBOX_PADDING 外扩）内的补丁。
+    """
+
+    def __init__(
+        self,
+        model: "EditorModel",
+        service: Any,
+        old_mask: Optional[np.ndarray],
+        new_mask: np.ndarray,
+        stroke_mask: np.ndarray,
+    ):
+        super().__init__("Brush Stroke")
+        self._model = model
+        self._service = service
+        self._mask_command = MaskEditCommand(
+            model=model, old_mask=old_mask, new_mask=new_mask
+        )
+        self._stroke = np.asarray(stroke_mask).copy()
+        self._img_shape: Optional[tuple[int, int]] = None
+        self._img_bounds: Optional[tuple[int, int, int, int]] = None
+        self._before_patch: Optional[np.ndarray] = None
+        self._after_patch: Optional[np.ndarray] = None
+
+        committed = model.get_committed_inpaint_artifact()
+        if committed is None or committed.image.ndim != 3:
+            return
+        image = committed.image
+        self._img_shape = image.shape[:2]
+        bounds = self._padded_stroke_bounds(self._stroke, self._img_shape)
+        if bounds is None:
+            return
+        self._img_bounds = bounds
+        y_min, y_max, x_min, x_max = bounds
+        self._before_patch = np.array(image[y_min:y_max, x_min:x_max], copy=True)
+
+    @staticmethod
+    def _padded_stroke_bounds(
+        stroke: np.ndarray, shape: tuple[int, int]
+    ) -> Optional[tuple[int, int, int, int]]:
+        """笔画包围盒外扩 padding；用笔画而非 stroke∩mask，保证覆盖实际改写范围。"""
+        if stroke.ndim != 2 or stroke.shape != shape or not np.any(stroke):
+            return None
+        ys, xs = np.where(stroke > 0)
+        height, width = shape
+        padding = INPAINT_BBOX_PADDING
+        return (
+            max(0, int(np.min(ys)) - padding),
+            min(height, int(np.max(ys)) + padding + 1),
+            max(0, int(np.min(xs)) - padding),
+            min(width, int(np.max(xs)) + padding + 1),
+        )
+
+    def _capture_after(self, image: Optional[np.ndarray]) -> None:
+        """强制重修结果落地后抓 after 补丁，让 redo 无需再跑一次修复器。"""
+        if image is None or self._img_bounds is None:
+            return
+        if np.asarray(image).shape[:2] != self._img_shape:
+            return
+        y_min, y_max, x_min, x_max = self._img_bounds
+        self._after_patch = np.array(image[y_min:y_max, x_min:x_max], copy=True)
+
+    def _restore_image_patch(self, patch: Optional[np.ndarray]) -> bool:
+        if patch is None or self._img_bounds is None:
+            return False
+        committed = self._model.get_committed_inpaint_artifact()
+        if committed is None or committed.image.shape[:2] != self._img_shape:
+            return False
+        y_min, y_max, x_min, x_max = self._img_bounds
+        image = np.array(committed.image, copy=True)
+        if patch.shape != image[y_min:y_max, x_min:x_max].shape:
+            return False
+        image[y_min:y_max, x_min:x_max] = patch
+        # 蒙版此时已经写回，推进代数号既作废在途修复，也给新 artifact 拿到合法 key。
+        key = self._model.bump_inpaint_revision()
+        if key is None:
+            return False
+        mask = self._service.normalize_binary_mask(self._model.get_effective_mask())
+        if mask is None or mask.shape != image.shape[:2] or not np.any(mask):
+            return False
+        return bool(
+            self._model.install_inpaint_artifact(InpaintArtifact(key, mask, image))
+        )
+
+    def redo(self):
+        # 压掉常规 delta 修复：随后的强制重修覆盖的区域是它的超集，否则白跑一次修复器。
+        with self._service.suspend_auto_inpaint():
+            self._mask_command.redo()
+        if self._restore_image_patch(self._after_patch):
+            return
+        self._service.force_inpaint_stroke(
+            self._stroke, on_installed=self._capture_after
+        )
+
+    def undo(self):
+        with self._service.suspend_auto_inpaint():
+            self._mask_command.undo()
+        if self._restore_image_patch(self._before_patch):
+            return
+        # 构造时还没有修复图可存（或补丁已失配），退回常规路径按当前蒙版重算。
+        self._service.ensure_current_mask_inpaint()
 
 
 class PaintOverlayEditCommand(QUndoCommand):

--- a/desktop_qt_ui/editor/controller_inpaint_service.py
+++ b/desktop_qt_ui/editor/controller_inpaint_service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import torch
@@ -13,6 +14,7 @@ from services import get_config_service
 from .document_state import normalize_binary_mask
 from .image_utils import image_like_to_rgb_array
 from .inpaint_state import (
+    INPAINT_BBOX_PADDING,
     InpaintArtifact,
     InpaintConfigSnapshot,
     InpaintKey,
@@ -34,6 +36,18 @@ class EditorControllerInpaintService:
 
     def __init__(self, controller: "EditorController"):
         self.controller = controller
+        # 画笔命令在写回蒙版时借此压掉常规 delta 修复，避免和随后的强制重修抢同一份工作。
+        self._suspend_auto_inpaint = 0
+        self._forced_callback: Optional[tuple[InpaintKey, Any]] = None
+
+    @contextlib.contextmanager
+    def suspend_auto_inpaint(self):
+        """临时压掉 effective_mask_delta_changed 触发的自动修复。"""
+        self._suspend_auto_inpaint += 1
+        try:
+            yield
+        finally:
+            self._suspend_auto_inpaint -= 1
 
     @property
     def logger(self):
@@ -130,16 +144,86 @@ class EditorControllerInpaintService:
 
     def apply_inpaint_result(self, result: object) -> None:
         if isinstance(result, _InpaintFailure):
+            self._take_forced_callback(result.key)
             self.model.fail_inpaint(result.key)
             return
         if not isinstance(result, InpaintArtifact):
             return
         if not self.model.install_inpaint_artifact(result):
+            self._take_forced_callback(result.key)
             self.logger.debug(
                 "Ignoring stale inpaint result (key %s, current %s)",
                 result.key,
                 self.model.get_inpaint_key(),
             )
+            return
+        callback = self._take_forced_callback(result.key)
+        if callback is not None:
+            callback(result.image)
+
+    def _take_forced_callback(self, key: InpaintKey):
+        """取出并清除该代数号登记的强制重修回调。"""
+        pending = self._forced_callback
+        if pending is None or pending[0] != key:
+            return None
+        self._forced_callback = None
+        return pending[1]
+
+    def force_inpaint_stroke(self, stroke_mask, *, on_installed=None) -> None:
+        """按笔画强制重修，无视该区域此前是否已经修复过。
+
+        优化蒙版是二值累积的：某个像素涂成 255 之后再涂一次不产生任何差异，常规
+        delta 路径因此把重复涂抹整条丢弃（见 build_inpaint_request 里减去已修复
+        footprint 的那段，以及同蒙版直接复用 artifact 的那段）。这里把笔画本身当作
+        added 区域直接下发，绕开这两道判定，让用户能在已修复处继续手动修。
+        """
+        current_mask = self._current_mask()
+        stroke = self.normalize_binary_mask(stroke_mask)
+        if (
+            current_mask is None
+            or stroke is None
+            or stroke.shape != current_mask.shape
+            or not np.any(current_mask)
+        ):
+            return
+        # 必须与当前蒙版求交：async_inpaint 把 added 直接当修复器蒙版，而 removed 为空时
+        # 不会执行“未蒙版像素还原为底图”，否则笔画溢出蒙版的部分会改写本该保持原样的像素。
+        forced = np.where((stroke > 0) & (current_mask > 0), 255, 0).astype(np.uint8)
+        if not np.any(forced):
+            return
+
+        # 推进代数号：蒙版未变时新旧请求的 key 与 mask 完全相同，不推进的话晚到的旧结果
+        # 会盖掉本次强制重修的结果。
+        key = self.model.bump_inpaint_revision()
+        if key is None:
+            return
+        image = self._get_base_image_array(key)
+        if image is None:
+            return
+        previous = self.model.get_committed_inpaint_artifact()
+        if previous is not None and previous.key.document_id != key.document_id:
+            previous = None
+        request = InpaintRequest(
+            key=key,
+            image=image,
+            mask=current_mask,
+            delta=MaskDelta(
+                added=forced,
+                removed=np.zeros_like(forced),
+                mask_revision=key.mask_revision,
+            ),
+            previous_artifact=previous,
+            config=self._snapshot_inpaint_config(),
+        )
+        future = self.async_service.submit_task(self.async_inpaint(request))
+        if not self.model.begin_inpaint(request.key, future):
+            return
+        self._forced_callback = (
+            (request.key, on_installed) if on_installed is not None else None
+        )
+        future.add_done_callback(
+            lambda completed, key=request.key: self._emit_inpaint_result(completed, key)
+        )
 
     def _start_inpaint_request(self, mask, delta: MaskDelta) -> None:
         request = self.build_inpaint_request(mask, delta)
@@ -182,6 +266,8 @@ class EditorControllerInpaintService:
         self.on_effective_mask_delta_changed(current_mask, delta)
 
     def on_effective_mask_delta_changed(self, mask, delta: MaskDelta) -> None:
+        if self._suspend_auto_inpaint:
+            return
         supplied_mask = self.normalize_binary_mask(mask)
         current_mask = self._current_mask()
         key = self.model.get_inpaint_key()
@@ -282,7 +368,7 @@ class EditorControllerInpaintService:
 
         if np.any(added_areas):
             ys, xs = np.where(added_areas > 0)
-            padding = 50
+            padding = INPAINT_BBOX_PADDING
             height, width = current_mask.shape
             y_min = max(0, int(np.min(ys)) - padding)
             y_max = min(height, int(np.max(ys)) + padding + 1)

--- a/desktop_qt_ui/editor/document_state.py
+++ b/desktop_qt_ui/editor/document_state.py
@@ -423,6 +423,26 @@ class EditorDocument:
             delta,
         )
 
+    def bump_inpaint_revision(self) -> InpaintKey:
+        """推进代数号以作废在途修复，但不改动蒙版（强制重修用）。
+
+        committed 必须保留：强制重修是在“当前修复图”上继续修，而不是从底图重跑。
+        旧 artifact 的蒙版没有变化，因此对新代数号依然成立，重新贴 key 即可，
+        否则 ready_inpaint_artifact() 会在异步窗口内返回 None，导出退化成
+        backend_inpaint 并丢掉编辑器已有的修复结果。
+        """
+        self.mask_revision += 1
+        committed = self.inpaint.committed
+        self.inpaint.invalidate(clear_committed=False)
+        key = self.inpaint_key()
+        if committed is not None:
+            # 只换 key，保留原始 mask，让 ready_artifact 仍按“蒙版是否相符”真实判定。
+            self.inpaint.install_ready(
+                InpaintArtifact(key, committed.mask, committed.image)
+            )
+            self.inpaint_display_image = committed.image
+        return key
+
     def ready_inpaint_artifact(self) -> Optional[InpaintArtifact]:
         return self.inpaint.ready_artifact(
             self.inpaint_key(),

--- a/desktop_qt_ui/editor/editor_model.py
+++ b/desktop_qt_ui/editor/editor_model.py
@@ -58,6 +58,9 @@ class EditorModel(QObject):
     def get_inpaint_key(self) -> InpaintKey:
         return self.session.get_inpaint_key()
 
+    def bump_inpaint_revision(self) -> Optional[InpaintKey]:
+        return self.session.bump_inpaint_revision()
+
     def _emit_document_projection(self) -> None:
         self.original_image_alpha_changed.emit(self.get_original_image_alpha())
         self.display_layers_changed.emit(self.get_display_layers())

--- a/desktop_qt_ui/editor/inpaint_state.py
+++ b/desktop_qt_ui/editor/inpaint_state.py
@@ -5,6 +5,10 @@ from typing import Any, Optional
 
 import numpy as np
 
+# 增量修复时在 added 区域包围盒外扩的像素数；撤销命令按同一常量截取修复图补丁，
+# 保证补丁覆盖 async_inpaint 实际可能改写的全部范围。
+INPAINT_BBOX_PADDING = 50
+
 
 def _owned_array(value: np.ndarray) -> np.ndarray:
     array = np.asarray(value)

--- a/desktop_qt_ui/editor/session.py
+++ b/desktop_qt_ui/editor/session.py
@@ -198,6 +198,10 @@ class EditorSession:
             return InpaintKey(self._next_document_id, 0)
         return document.inpaint_key()
 
+    def bump_inpaint_revision(self) -> Optional[InpaintKey]:
+        document = self._document
+        return None if document is None else document.bump_inpaint_revision()
+
     def get_ready_inpaint_artifact(self) -> Optional[InpaintArtifact]:
         document = self._document
         return None if document is None else document.ready_inpaint_artifact()

--- a/desktop_qt_ui/ui/editor/graphics_view_input.py
+++ b/desktop_qt_ui/ui/editor/graphics_view_input.py
@@ -523,7 +523,8 @@ class GraphicsViewInputMixin:
         )
 
         new_mask_np = base_mask.copy()
-        if self._active_tool in ("pen", "brush"):
+        is_brush = self._active_tool in ("pen", "brush")
+        if is_brush:
             new_mask_np[stroke_mask > 0] = 255
         elif self._active_tool == "eraser":
             new_mask_np[stroke_mask > 0] = 0
@@ -533,7 +534,26 @@ class GraphicsViewInputMixin:
         mask_changed = (old_mask_np is None and np.any(new_mask_np)) or (
             old_mask_np is not None and not np.array_equal(old_mask_np, new_mask_np)
         )
-        if not self.controller or not mask_changed:
+        if not self.controller or not np.any(stroke_mask):
+            return
+
+        if is_brush:
+            # 画笔一律强制重修：涂在已有蒙版内不会改变蒙版（二值累积），但用户要的正是
+            # “在已修复处再修一次”，因此不能像橡皮擦那样以蒙版无变化为由丢弃这一笔。
+            from editor.commands import BrushStrokeCommand
+
+            self.controller.execute_command(
+                BrushStrokeCommand(
+                    model=self.model,
+                    service=self.controller.inpaint_service,
+                    old_mask=old_mask_np,
+                    new_mask=new_mask_np.copy(),
+                    stroke_mask=stroke_mask,
+                )
+            )
+            return
+
+        if not mask_changed:
             return
 
         from editor.commands import MaskEditCommand

--- a/doc/wiki/en/desktop/editor/mask-paint-and-clone-stamp.md
+++ b/doc/wiki/en/desktop/editor/mask-paint-and-clone-stamp.md
@@ -13,7 +13,7 @@ When the auto-generated repair mask misses text ghosts, covers too much backgrou
 
 ## What you can do
 
-- The mask brush (`brush`) and eraser (`eraser`) edit the **refined mask** (`refined_mask`, a binary 0/255 array), not the raw mask produced by detection. Each effective stroke commits one `MaskEditCommand` and triggers one auto-inpaint pass.
+- The mask brush (`brush`) and eraser (`eraser`) edit the **refined mask** (`refined_mask`, a binary 0/255 array), not the raw mask produced by detection. Brush strokes commit a `BrushStrokeCommand` and trigger forced repair; eraser strokes commit a `MaskEditCommand` and trigger incremental auto-inpainting on mask changes.
 - The color brush (`paint`, `paint_erase`) writes the **paint layer** (`paint_overlay`, RGBA); the clone stamp (`clone`, `stamp_erase`) writes the **stamp layer** (`stamp_overlay`, RGBA). These two layers are independent transparent layers above the inpainted image and never enter mask binarization.
 - “Clear All Masks” clears the refined mask (falling back to the raw mask when no refined mask exists); “Clear Paint Layer” and “Clear Stamp Layer” clear the corresponding RGBA layers. All three go through undoable commands.
 - This guide does not cover tool-button switching, selection, zoom/pan, context menus, or shortcut registration (see [Canvas Tools and Selection](./canvas-tools-and-selection.md) and [Shortcuts](./shortcuts.md)), nor the global inpainter model, size, precision, and per-block settings (see [Settings → Mask and Inpainting](../settings/mask-and-inpainting.md)).
@@ -29,7 +29,7 @@ After opening the editor, the left panel defaults to “Property Editor”. The 
 1. Open the “Mask” tab.
 2. Click “Brush” or “Eraser”; alternatively press `W` / `E` to switch without opening the panel.
 3. Drag the “Brush Size:” slider to adjust stroke thickness; the range is 5–200 with an initial value of 30. On the canvas, `Shift+wheel` adjusts the same field by ±1 per notch.
-4. Press and drag the left button on the canvas: the brush writes 255 at the stroke position, and the eraser clears the stroke position to 0. On release, the whole stroke is committed as one undoable command and triggers one auto-inpaint pass.
+4. Press and drag the left button on the canvas: the brush writes 255 at the stroke position, committing a `BrushStrokeCommand` for forced repair on release; the eraser clears the stroke position to 0, committing a `MaskEditCommand` for incremental repair on release. Both enter the undo stack as undoable commands.
 5. Check “Show Refined Mask” to display the refined mask as a semi-transparent red overlay on the canvas; click “Clear All Masks” to clear the refined mask entirely.
 
 ### Paint tab: color brush
@@ -74,9 +74,10 @@ The inpainted image, paint layer, and stamp layer are all stacked above the base
 ### Mask strokes and auto-inpainting
 
 - `_build_stroke_mask` connects the press points into a round-cap polyline and converts the stroke to mask resolution using “brush size × mask/image size ratio”; the mask resolution follows `refined_mask`, falling back to base-image pixel size when no refined mask exists.
-- On commit, the old and new masks are compared; only real changes construct a `MaskEditCommand` (storing the old/new pixel patch inside the change bounding box), executed through the `QUndoStack`.
-- After a brush stroke, `force_inpaint_stroke(stroke_mask)` runs an incremental inpaint limited to the stroke bounding box (padded by 50 px) instead of re-running the whole image. After an eraser stroke, the `refined_mask_changed` signal computes “added/removed” areas from the cached mask snapshot and inpaints incrementally; removed areas are restored directly from the base image.
-- Inpaint requests carry a generation number `_inpaint_request_generation`: a new stroke cancels and supersedes the unfinished old request, so with rapid successive strokes the canvas settles on the result of the latest request.
+- A brush stroke commits a `BrushStrokeCommand`: it first writes the mask back (recording the old/new pixel patch inside the change bounding box, when there is a change), then calls `force_inpaint_stroke(stroke_mask)` to force a repair. **The refined mask is binary and cumulative, so painting over an already-repaired area produces no mask difference**; the brush therefore must not skip on “mask unchanged” — otherwise the same spot could never be repaired manually a second time. The forced path submits the stroke itself (intersected with the current mask) as the added region, bypassing both the “subtract the already-repaired footprint” and “reuse the artifact for an identical mask” gates of the normal delta path. It re-runs only the stroke bounding box (padded by `INPAINT_BBOX_PADDING`, 50 px) and feeds the **current repaired image** as input, so repeated strokes refine iteratively instead of restarting from the base image.
+- An eraser stroke commits a `MaskEditCommand` and goes through the `effective_mask_delta_changed` signal, which computes “added/removed” areas from the mask snapshot and inpaints incrementally; removed areas are restored directly from the base image.
+- Forced repair makes the repaired image no longer a pure function of `f(base, mask)`, so undo cannot recompute it. `BrushStrokeCommand` therefore stores pixels the way the paint layer does: it records only the repaired-image patch inside the stroke bounding box, restoring the before patch on undo and the first result's after patch on redo (without re-running the inpainter). While the mask is written back, `suspend_auto_inpaint()` blocks the normal delta repair so it does not compete with the forced repair that follows.
+- Inpaint requests carry the generation number `mask_revision` (one half of `InpaintKey`): every forced repair calls `bump_inpaint_revision()` to advance it so any request still in flight from before the stroke is invalidated by key mismatch — when the mask is unchanged both requests carry an identical mask, and without the bump a late-arriving old result would overwrite the new one. The bump also re-keys the committed artifact (the mask did not change, so it still holds); otherwise `ready_inpaint_artifact()` would return None during the async window and export would degrade to `backend_inpaint`, discarding the repair the editor already has.
 - The inpainter itself uses `inpainter`, `inpainting_size`, `inpainting_precision`, and `force_use_torch_inpainting` from settings, on `cuda` (when GPU is enabled and available) or `cpu`; see [Settings → Mask and Inpainting](../settings/mask-and-inpainting.md).
 - Stroke preview colors: mask brush is semi-transparent red, eraser is semi-transparent blue, color brush uses the chosen color, paint/stamp erasers are semi-transparent cyan, and the clone stamp shows the real stamped pixels.
 
@@ -111,7 +112,8 @@ flowchart LR
 
 Mask strokes, clearing all masks, paint/stamp strokes, and layer clearing all enter the same `QUndoStack`:
 
-- `MaskEditCommand`: undo/redo writes `refined_mask` back through the patch or the full array. The write-back also emits `refined_mask_changed`, so undoing/redoing a mask edit re-triggers auto-inpainting.
+- `MaskEditCommand` (eraser): undo/redo writes `refined_mask` back through the patch or the full array. The write-back also emits the mask delta signal, so undoing/redoing re-triggers auto-inpainting.
+- `BrushStrokeCommand` (brush): a single undo entry carrying both the mask patch and the repaired-image patch. Both write the mask inside `suspend_auto_inpaint()`; undo restores the before patch and redo applies the cached after patch without re-running the inpainter when patch restoration succeeds. If the patch is missing or mismatched, undo falls back to `ensure_current_mask_inpaint()` to recompute from the current mask, while redo falls back to `force_inpaint_stroke()` to re-run forced repair.
 - `PaintOverlayEditCommand`: `layer='paint'` acts on the paint layer and `layer='stamp'` on the stamp layer; undo/redo only changes pixels of the corresponding layer and never triggers inpainting.
 - The undo granularity is the whole stroke, not an individual dab; the focus rules for `Ctrl+Z`/`Ctrl+Y` are covered in [Shortcuts](./shortcuts.md).
 

--- a/doc/wiki/zh/desktop/editor/mask-paint-and-clone-stamp.md
+++ b/doc/wiki/zh/desktop/editor/mask-paint-and-clone-stamp.md
@@ -13,7 +13,7 @@ lastUpdated: true
 
 ## 可以做什么
 
-- 蒙版画笔（`brush`）和橡皮擦（`eraser`）编辑的是**优化蒙版**（`refined_mask`，二值数组 0/255），不是检测输出的原始蒙版；每次有效笔画提交一个 `MaskEditCommand`，并触发一次自动修复。
+- 蒙版画笔（`brush`）和橡皮擦（`eraser`）编辑的是**优化蒙版**（`refined_mask`，二值数组 0/255），不是检测输出的原始蒙版；画笔提交 `BrushStrokeCommand` 并触发强制修复，橡皮擦提交 `MaskEditCommand` 并在蒙版变化时触发增量自动修复。
 - 彩色画笔（`paint`、`paint_erase`）写入**画笔图层**（`paint_overlay`，RGBA）；仿制印章（`clone`、`stamp_erase`）写入**印章图层**（`stamp_overlay`，RGBA）。这两层是覆盖在修复图之上的独立透明层，不参与蒙版二值化。
 - “清除所有蒙版”清空的是优化蒙版（没有优化蒙版时以原始蒙版为起点清零）；“清除画笔图层”“清除印章图层”分别清空对应 RGBA 层，三者都走可撤销命令。
 - 这里不负责工具按钮切换、选区、缩放平移、右键菜单和快捷键注册（见[画布工具与选区](./canvas-tools-and-selection.md)与[快捷键](./shortcuts.md)），也不负责修复器模型、修复尺寸、精度和逐块修复等全局参数（见[设置 → 蒙版与修复](../settings/mask-and-inpainting.md)）。
@@ -29,7 +29,7 @@ lastUpdated: true
 1. 打开“蒙版”页签。
 2. 点击“画笔”或“橡皮擦”；也可以直接按 `W` / `E` 切换，无需打开面板。
 3. 拖动“笔刷大小：”滑条调整笔画粗细，范围 5–200，初始 30；在画布上按住 `Shift+滚轮` 每格 ±1 调整同一个字段。
-4. 在画布上按住左键拖动：画笔把笔画位置写为 255，橡皮擦把笔画位置清为 0。松开后整笔作为一个可撤销命令提交，并触发一次自动修复。
+4. 在画布上按住左键拖动：画笔把笔画位置写为 255，松开后提交 `BrushStrokeCommand` 并强制重修；橡皮擦把笔画位置清为 0，松开后提交 `MaskEditCommand` 并增量修复。两者均作为可撤销命令进入撤销栈。
 5. 勾选“显示优化蒙版”在画布上以半透明红色显示优化蒙版；点击“清除所有蒙版”把优化蒙版整体清空。
 
 ### 画笔页签：彩色画笔
@@ -74,9 +74,10 @@ flowchart LR
 ### 蒙版笔画与自动修复
 
 - `_build_stroke_mask` 把落笔点连成带圆头的折线，再按“笔刷大小 × 蒙版/图像尺寸比”换算成蒙版分辨率下的二值笔画；蒙版分辨率以 `refined_mask` 为准，没有优化蒙版时以底图像素尺寸为准。
-- 提交时比较新旧蒙版，只有实际变化才构造 `MaskEditCommand`（记录变化包围盒内的旧/新像素补丁），通过 `QUndoStack` 执行。
-- 画笔提交后调用 `force_inpaint_stroke(stroke_mask)`，只用本次笔画包围盒（外扩 50px）做增量修复，而不是整图重跑；橡皮擦提交后走 `refined_mask_changed` 信号，由缓存蒙版快照计算“新增/移除”区域后增量修复，移除区域直接恢复为底图像素。
-- 修复请求带代数号 `_inpaint_request_generation`：新笔画会取消并取代未完成的旧请求，所以连续快速涂抹时，画面最终以最后一次请求的结果为准。
+- 画笔提交 `BrushStrokeCommand`：先写回蒙版（有变化才记录变化包围盒内的旧/新像素补丁），再调用 `force_inpaint_stroke(stroke_mask)` 强制重修。**优化蒙版是二值累积的，涂在已修复区域不会产生蒙版差异**，因此画笔不能以“蒙版无变化”为由跳过——否则同一处永远无法再次手动修复。强制路径把笔画本身（与当前蒙版求交后）当作新增区域下发，绕开常规 delta 路径里“减去已修复 footprint”和“同蒙版复用 artifact”两道判定，只重跑笔画包围盒（外扩 `INPAINT_BBOX_PADDING`，50px），并以**当前修复图**为输入，因此重复涂抹是逐次精修而不是从底图重来。
+- 橡皮擦提交 `MaskEditCommand`，走 `effective_mask_delta_changed` 信号，由蒙版快照计算“新增/移除”区域后增量修复，移除区域直接恢复为底图像素。
+- 强制重修让修复图不再是 `f(底图, 蒙版)` 的纯函数，撤销无法靠重算得到，因此 `BrushStrokeCommand` 像画笔图层那样存像素：只记录笔画包围盒内的修复图补丁，撤销贴回 before 补丁，重做贴回首次结果的 after 补丁（不重跑修复器）。写回蒙版期间用 `suspend_auto_inpaint()` 压掉常规 delta 修复，避免和随后的强制重修抢同一份工作。
+- 修复请求带代数号 `mask_revision`（`InpaintKey` 的一半）：每次强制重修都会 `bump_inpaint_revision()` 推进它，让笔画之前在途的旧结果因 key 不匹配而失效——蒙版未变时新旧请求的蒙版完全相同，不推进代数号的话晚到的旧结果会盖掉本次结果。推进时会给已提交 artifact 重贴新 key（蒙版没变，它依然成立），否则异步窗口内 `ready_inpaint_artifact()` 返回 None，导出会退化成 `backend_inpaint` 并丢掉编辑器已有的修复结果。
 - 修复器本身使用设置中的 `inpainter`、`inpainting_size`、`inpainting_precision`、`force_use_torch_inpainting`，设备为 `cuda`（开启 GPU 且可用时）或 `cpu`，详见[设置 → 蒙版与修复](../settings/mask-and-inpainting.md)。
 - 笔画预览颜色：蒙版画笔为半透明红色、橡皮擦为半透明蓝色、彩色画笔为所选颜色、画笔/印章擦除为半透明青色；仿制印章直接显示真实盖印像素。
 
@@ -111,7 +112,8 @@ flowchart LR
 
 蒙版笔画、清除所有蒙版、画笔/印章笔画和图层清除都进入同一个 `QUndoStack`：
 
-- `MaskEditCommand`：undo/redo 通过补丁或全量数组写回 `refined_mask`；写回同样触发 `refined_mask_changed`，因此撤销/重做蒙版编辑也会重新触发自动修复。
+- `MaskEditCommand`（橡皮擦）：undo/redo 通过补丁或全量数组写回 `refined_mask`；写回同样触发蒙版增量信号，因此撤销/重做也会重新触发自动修复。
+- `BrushStrokeCommand`（画笔）：一条撤销条目同时含蒙版补丁和修复图补丁。两者都在 `suspend_auto_inpaint()` 内写回蒙版；撤销优先贴回 before 补丁，重做优先贴回首次结果的 after 补丁，补丁恢复成功时不会额外跑修复器。若补丁缺失或失配，撤销回退到 `ensure_current_mask_inpaint()` 按当前蒙版重算，重做回退到 `force_inpaint_stroke()` 重新强制修复。
 - `PaintOverlayEditCommand`：`layer='paint'` 作用于画笔层，`layer='stamp'` 作用于印章层；undo/redo 只改对应层像素，不触发修复。
 - 撤销粒度是“整笔”，不是单个取样点；`Ctrl+Z`/`Ctrl+Y` 的焦点规则见[快捷键](./shortcuts.md)。
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+"""测试入口的公共前置。
+
+与 desktop_qt_ui/main.py:50 同理：必须在任何 PyQt6 导入之前加载 PyTorch，否则
+PyQt6 的 Qt DLL 路径会干扰 c10.dll 初始化，在 Windows 上抛 WinError 1114。
+参考: https://github.com/pytorch/pytorch/issues/166628
+"""
+
+try:
+    import torch  # noqa: F401
+except ImportError:
+    pass

--- a/test/test_editor_forced_inpaint.py
+++ b/test/test_editor_forced_inpaint.py
@@ -1,0 +1,331 @@
+"""画笔强制重修（已修复区域再次手动修复）的回归测试。
+
+只在 _dispatch_inpaint 和配置快照两处打桩，其余走真实的 EditorModel / EditorSession /
+EditorDocument / InpaintState，以便覆盖真实的代数号与 artifact 编排。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+
+import numpy as np
+import pytest
+
+from editor.commands import BrushStrokeCommand
+from editor.controller_inpaint_service import EditorControllerInpaintService
+from editor.document_state import DocumentSnapshot
+from editor.editor_model import EditorModel
+from editor.inpaint_state import (
+    INPAINT_BBOX_PADDING,
+    InpaintArtifact,
+    InpaintConfigSnapshot,
+    MaskDelta,
+)
+
+H, W = 120, 160
+SOURCE_FILL = 10
+COMMITTED_FILL = 90
+DISPATCH_FILL = 200
+
+
+class _SyncAsyncService:
+    """同步跑完协程，让 add_done_callback 立即回调，测试无需等异步。"""
+
+    def submit_task(self, coro):
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001 - 转交给 _emit_inpaint_result
+            future.set_exception(exc)
+        return future
+
+
+class _DirectSignal:
+    def __init__(self):
+        self._sink = None
+
+    def connect(self, sink):
+        self._sink = sink
+
+    def emit(self, value):
+        if self._sink is not None:
+            self._sink(value)
+
+
+class _FakeController:
+    def __init__(self, model):
+        self.model = model
+        self.logger = logging.getLogger("test.forced_inpaint")
+        self.async_service = _SyncAsyncService()
+        self._inpaint_result_ready = _DirectSignal()
+
+
+def _source_image() -> np.ndarray:
+    return np.full((H, W, 3), SOURCE_FILL, dtype=np.uint8)
+
+
+def _rect_mask(y0: int, y1: int, x0: int, x1: int) -> np.ndarray:
+    mask = np.zeros((H, W), dtype=np.uint8)
+    mask[y0:y1, x0:x1] = 255
+    return mask
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """带一个已提交 artifact 的编辑器：蒙版覆盖 (20:60, 20:60)，修复图为纯色。"""
+    model = EditorModel()
+    mask = _rect_mask(20, 60, 20, 60)
+    model.session.load_document(
+        DocumentSnapshot(source_path="t.png", image=_source_image(), raw_mask=mask)
+    )
+
+    controller = _FakeController(model)
+    service = EditorControllerInpaintService(controller)
+    controller._inpaint_result_ready.connect(service.apply_inpaint_result)
+    # 与 editor_controller.py:235 的真实接线一致；不连这条，抑制类断言会空跑通过。
+    model.effective_mask_delta_changed.connect(service.on_effective_mask_delta_changed)
+
+    monkeypatch.setattr(
+        EditorControllerInpaintService,
+        "_snapshot_inpaint_config",
+        lambda self: InpaintConfigSnapshot("lama_large", "fp32", False, 2048, "cpu"),
+    )
+
+    calls: list[dict] = []
+
+    async def fake_dispatch(request, image, mask_arg):
+        calls.append(
+            {
+                "image": np.array(image, copy=True),
+                "mask": np.array(mask_arg, copy=True),
+                "shape": image.shape,
+            }
+        )
+        return np.full(image.shape, DISPATCH_FILL, dtype=np.uint8)
+
+    monkeypatch.setattr(
+        EditorControllerInpaintService, "_dispatch_inpaint", staticmethod(fake_dispatch)
+    )
+
+    # 装入一份“已经修复过”的 artifact，模拟流水线或先前笔画的结果。
+    committed = InpaintArtifact(
+        model.get_inpaint_key(),
+        mask,
+        np.full((H, W, 3), COMMITTED_FILL, dtype=np.uint8),
+    )
+    assert model.install_inpaint_artifact(committed)
+
+    return {
+        "model": model,
+        "service": service,
+        "calls": calls,
+        "mask": mask,
+    }
+
+
+# --- bump_inpaint_revision -------------------------------------------------
+
+
+def test_bump_keeps_artifact_ready_and_export_paired(env):
+    """推进代数号不能让导出退化成 backend_inpaint，否则会丢掉已有修复图。"""
+    model = env["model"]
+    document = model.session._document
+    before = model.get_inpaint_key()
+
+    key = model.bump_inpaint_revision()
+
+    assert key.mask_revision == before.mask_revision + 1
+    ready = document.ready_inpaint_artifact()
+    assert ready is not None, "重贴 key 失败，异步窗口内 artifact 会失效"
+    assert ready.key == key
+    assert document.export_base().kind == "paired"
+    # 只换 key，mask 必须保持真实，供后续 delta 相减使用。
+    assert np.array_equal(ready.mask, env["mask"])
+    assert int(ready.image[0, 0, 0]) == COMMITTED_FILL
+
+
+def test_stale_result_rejected_after_bump(env):
+    """代数号推进后，笔画之前在途的旧结果必须装不进去。"""
+    model = env["model"]
+    stale_key = model.get_inpaint_key()
+    model.bump_inpaint_revision()
+
+    stale = InpaintArtifact(
+        stale_key, env["mask"], np.zeros((H, W, 3), dtype=np.uint8)
+    )
+    assert model.install_inpaint_artifact(stale) is False
+
+
+# --- 核心回归：已修复区域重复涂抹 ------------------------------------------
+
+
+def test_repeat_brush_inside_repaired_area_dispatches_again(env):
+    """本次修复的主目标：整笔落在已修复蒙版内，仍要真正重跑一次修复器。"""
+    model, service, calls = env["model"], env["service"], env["calls"]
+    mask = env["mask"]
+    stroke = _rect_mask(30, 40, 30, 40)  # 完全位于 (20:60, 20:60) 之内
+
+    # 修复前的行为：涂在已有蒙版内不改变蒙版，常规 delta 路径整条丢弃这一笔。
+    unchanged = mask.copy()
+    unchanged[stroke > 0] = 255
+    assert np.array_equal(unchanged, mask), "该笔本就不改变蒙版，才是这个 bug 的前提"
+    delta = MaskDelta(
+        added=unchanged,
+        removed=np.zeros_like(unchanged),
+        mask_revision=model.get_inpaint_key().mask_revision,
+    )
+    assert service.build_inpaint_request(unchanged, delta) is None
+
+    # 修复后的行为：强制路径绕开上述判定，真正派发一次。
+    service.force_inpaint_stroke(stroke)
+
+    assert len(calls) == 1, "重复涂抹被当成 no-op 丢弃了"
+    # 迭代精修：输入必须是当前修复图，而不是底图。
+    assert int(calls[0]["image"][0, 0, 0]) == COMMITTED_FILL
+    assert int(np.max(calls[0]["mask"])) == 255
+
+
+def test_normal_delta_path_still_skips_noop(env):
+    """对照组：常规 delta 路径仍应丢弃无变化的蒙版（未破坏既有行为）。"""
+    service = env["service"]
+    mask = env["mask"]
+    delta = MaskDelta(
+        added=mask,
+        removed=np.zeros_like(mask),
+        mask_revision=env["model"].get_inpaint_key().mask_revision,
+    )
+    assert service.build_inpaint_request(mask, delta) is None
+
+
+def test_forced_region_is_clipped_to_current_mask(env):
+    """笔画溢出蒙版的部分不能进修复器，否则会改写本该保持原样的像素。"""
+    service, calls = env["service"], env["calls"]
+    mask = env["mask"]
+    stroke = _rect_mask(30, 40, 50, 100)  # 右半截伸到蒙版之外
+
+    service.force_inpaint_stroke(stroke)
+
+    assert len(calls) == 1
+    call = calls[0]
+    # 还原 bbox 偏移，把 dispatch 蒙版放回全图坐标系比对。
+    ys, xs = np.where(stroke > 0)
+    y0 = max(0, int(np.min(ys)) - INPAINT_BBOX_PADDING)
+    x0 = max(0, int(np.min(xs)) - INPAINT_BBOX_PADDING)
+    full = np.zeros((H, W), dtype=np.uint8)
+    sub = call["mask"]
+    full[y0 : y0 + sub.shape[0], x0 : x0 + sub.shape[1]] = sub
+    assert not np.any((full > 0) & (mask == 0)), "强制区域越出了当前蒙版"
+    assert np.array_equal(full > 0, (stroke > 0) & (mask > 0))
+
+
+def test_forced_stroke_outside_mask_is_dropped(env):
+    """完全在蒙版外的笔画求交后为空，不应触发修复。"""
+    service, calls = env["service"], env["calls"]
+    before = env["model"].get_inpaint_key()
+
+    service.force_inpaint_stroke(_rect_mask(90, 100, 90, 100))
+
+    assert calls == []
+    assert env["model"].get_inpaint_key() == before, "空笔画不应推进代数号"
+
+
+def test_forced_result_installs_and_becomes_display_image(env):
+    """强制重修的结果要落到 committed / 显示图上。"""
+    model, service = env["model"], env["service"]
+    service.force_inpaint_stroke(_rect_mask(30, 40, 30, 40))
+
+    committed = model.get_committed_inpaint_artifact()
+    assert committed is not None
+    assert committed.key == model.get_inpaint_key()
+    # bbox 内被换成 dispatch 结果，bbox 外仍是原修复图。
+    assert int(committed.image[35, 35, 0]) == DISPATCH_FILL
+    assert int(committed.image[H - 1, W - 1, 0]) == COMMITTED_FILL
+    assert model.session._document.inpaint_display_image is committed.image
+
+
+def test_suspend_auto_inpaint_blocks_delta_path(env):
+    """抑制期内常规 delta 修复不得启动，避免和强制重修抢同一份工作。"""
+    model, service, calls = env["model"], env["service"], env["calls"]
+    with service.suspend_auto_inpaint():
+        model.set_refined_mask(_rect_mask(20, 60, 20, 80))
+    assert calls == []
+
+
+def test_delta_path_still_repairs_when_not_suspended(env):
+    """守护既有行为：非抑制状态下扩大蒙版仍应触发常规增量修复。"""
+    model, service, calls = env["model"], env["service"], env["calls"]
+    model.set_refined_mask(_rect_mask(20, 60, 20, 80))
+    assert len(calls) == 1, "常规 delta 修复被误伤"
+    assert service is not None
+
+
+def test_suspend_restores_counter_after_exception(env):
+    """抑制是引用计数式的，异常路径也必须恢复，否则自动修复会永久失效。"""
+    service, calls = env["service"], env["calls"]
+    with pytest.raises(RuntimeError):
+        with service.suspend_auto_inpaint():
+            raise RuntimeError("boom")
+    assert service._suspend_auto_inpaint == 0
+    env["model"].set_refined_mask(_rect_mask(20, 60, 20, 80))
+    assert len(calls) == 1
+
+
+# --- BrushStrokeCommand 撤销/重做 ------------------------------------------
+
+
+def _make_command(env, stroke, new_mask=None):
+    model = env["model"]
+    old_mask = model.get_refined_mask()
+    return BrushStrokeCommand(
+        model=model,
+        service=env["service"],
+        old_mask=old_mask,
+        new_mask=env["mask"].copy() if new_mask is None else new_mask,
+        stroke_mask=stroke,
+    )
+
+
+def test_command_redo_repairs_then_undo_restores_previous_image(env):
+    model, calls = env["model"], env["calls"]
+    stroke = _rect_mask(30, 40, 30, 40)
+    command = _make_command(env, stroke)
+
+    command.redo()
+    assert len(calls) == 1
+    assert int(model.get_committed_inpaint_artifact().image[35, 35, 0]) == DISPATCH_FILL
+
+    command.undo()
+    restored = model.get_committed_inpaint_artifact()
+    assert restored is not None
+    assert int(restored.image[35, 35, 0]) == COMMITTED_FILL, "撤销没有还原修复图"
+    assert restored.key == model.get_inpaint_key()
+    assert len(calls) == 1, "撤销不应再跑修复器"
+
+
+def test_command_redo_reuses_after_patch_without_dispatch(env):
+    """redo 复用首次结果的补丁，不重复跑修复器。"""
+    model, calls = env["model"], env["calls"]
+    command = _make_command(env, _rect_mask(30, 40, 30, 40))
+
+    command.redo()
+    command.undo()
+    command.redo()
+
+    assert len(calls) == 1, "redo 又跑了一次修复器"
+    assert int(model.get_committed_inpaint_artifact().image[35, 35, 0]) == DISPATCH_FILL
+
+
+def test_command_undo_restores_mask_when_stroke_grew_it(env):
+    """笔画扩大蒙版时，撤销要同时还原蒙版和修复图。"""
+    model = env["model"]
+    grown = _rect_mask(20, 60, 20, 100)
+    command = _make_command(env, _rect_mask(30, 40, 55, 95), new_mask=grown)
+
+    command.redo()
+    assert np.array_equal(model.get_refined_mask(), grown)
+
+    command.undo()
+    assert np.array_equal(model.get_refined_mask(), env["mask"])
+    assert int(model.get_committed_inpaint_artifact().image[35, 70, 0]) == COMMITTED_FILL


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #

## 改动说明 / Summary

### 1. 问题背景
优化蒙版（refined mask）是二值且累积的，当用户在已有蒙版的区域再次用画笔涂抹时，蒙版数据不会产生任何差异（diff 为空）。在重构为 delta/artifact 架构后，修复流水线的各个阶段都将这种情况视作无操作（no-op）直接跳过，导致用户在已修复区域进行二次涂抹时无法触发再次修复——此前用户必须先用橡皮擦擦除该区域，然后再重新涂抹。

Wiki 文档中原本记录了通过 `force_inpaint_stroke(stroke_mask)` 进行强制重修的机制，但在迁移到 delta/artifact 架构时遗漏了该路径的实现，属于功能回归。

### 2. 解决方案与核心改动
- **恢复强制修复路径 `force_inpaint_stroke()`**：
  将本次笔画本身（与当前有效蒙版求交后）作为 `added` 区域直接下发，绕开“减去已修复 footprint”和“同蒙版复用 artifact”两道判定。
  *注：笔画必须与当前蒙版求交，因为 `async_inpaint` 会将 `delta.added` 直接输入修复器，而在 `removed` 为空时不会执行底图还原；若不求交，笔画伸出蒙版的部分会错误改写本应保持原样的像素。*
- **代数号推进与旧结果作废 `bump_inpaint_revision()`**：
  在强制修复时递增 `mask_revision`。因为蒙版未变，前后两次请求的 mask 完全相同，如果不推进代数号，晚到的旧请求结果会因 key 相同而覆盖本次新结果。同时为已提交的 artifact 重新贴上新 key，防止在异步等待窗口内 `ready_inpaint_artifact()` 返回 None 导致导出流程回退到 `backend_inpaint` 而丢弃已有修复效果。
- **完善撤销/重做机制 `BrushStrokeCommand`**：
  强制修复使修复图像不再是单纯的 `f(底图, 蒙版)` 纯函数，撤销无法靠重算蒙版得到。因此 `BrushStrokeCommand` 像绘制图层一样，记录笔画包围盒（外扩 `INPAINT_BBOX_PADDING` 50px）内的修复图局部 patch；在写回蒙版时通过 `suspend_auto_inpaint()` 临时抑制常规的 delta 自动修复，避免与随后的强制重修产生冲突与重复计算。
- **橡皮擦路径保持不变**：
  橡皮擦依然提交 `MaskEditCommand` 走常规的 delta 增量修复流水线。
- **Wiki 文档与测试**：
  同步修正了中英文 Wiki 中关于画笔自动修复与撤销栈的说明；新增完整单元测试覆盖判定绕过、蒙版求交、过期结果丢弃、撤销/重做等场景。

### 3. 已知权衡（Trade-off）
每个画笔笔画在撤销栈（Undo Stack）中会保留其外扩包围盒范围的 RGB patch。撤销深度较大且在大图上大面积涂抹时会占用一定内存，这是支持强制修复可撤销的必要开销。

## 改动类型 / Type of Change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 界面或交互调整 / UI or UX change
- [ ] 重构或性能优化 / Refactor or performance improvement
- [x] 文档或翻译 / Documentation or translation
- [ ] 其他 / Other

## 验证 / Verification

- 验证命令或步骤 / Commands or steps:
  1. 新增专项单元测试：`pytest test/test_editor_forced_inpaint.py -q`
     测试使用 fake dispatcher，覆盖：常规 delta 路径对无差异笔画的跳过判定、完全落在蒙版内的笔画成功派发强制修复、强制区域正确裁剪到蒙版内、蒙版外笔画被丢弃且不推进代数号、代数号推进后在途旧结果被正确拒绝、`export_base()` 保持 paired 状态、`suspend_auto_inpaint()` 抑制信号有效性、`BrushStrokeCommand` 撤销/重做无需重跑修复器即可还原像素。
  2. 运行全量测试套件验证无回归：`pytest -q`
  3. 编辑器手动验证：在已修复的区域上使用画笔重复涂抹，修复器能正常重新触发精修；使用 Ctrl+Z / Ctrl+Y 能准确撤销与重做画面变化。

- 验证结果 / Result:
  1. `13 passed`
  2. `474 passed, 2 skipped, 9 subtests passed`（所有既有测试全部通过，包括 `test_editor_inpaint_cache_reset.py` 和 `test_editor_document_state.py`）。
  3. 编辑器内重复涂抹响应正常，撤销/重做像素还原准确。

*(注：`test/conftest.py` 在 Windows 下预先导入 torch，解决 PyQt6 引起的 `c10.dll` 1114 加载冲突，在 Linux/CI 环境为无操作。)*

## 截图或录屏 / Screenshots or Recordings

N/A

## 提交检查 / Checklist

- [x] 已同步上游仓库的最新默认分支并处理冲突。/ Synchronized with the latest upstream default branch and resolved conflicts.
- [x] 只提交与当前问题有关的文件，不包含编辑器配置、临时文件、运行产物、个人配置或无关格式化。/ Included only files related to this change; no editor settings, temporary files, runtime output, personal configuration, or unrelated formatting.
- [x] 代码遵循仓库现有结构和风格，不包含调试输出、注释掉的旧代码、未使用导入、死代码或临时兼容逻辑。/ Followed existing repository patterns and removed debug output, commented-out old code, unused imports, dead code, and temporary compatibility logic.
- [x] 已更新所有受影响的调用方，以及必要的测试、文档和中英文内容。/ Updated all affected callers and any necessary tests, documentation, and Chinese/English content.
- [x] 已验证实际改动，并在上方写明验证命令、步骤和结果。/ Verified the actual change and documented the commands, steps, and results above.
- [x] 已确认提交内容不包含 API Key、Token、Cookie、账号、个人路径或其他敏感信息。/ Confirmed that the PR contains no API keys, tokens, cookies, accounts, personal paths, or other sensitive information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brush strokes now force image repair, including over already-repaired areas.
  * Undo and redo preserve both mask edits and repaired image results.
  * New strokes safely invalidate outdated in-flight repairs.
  * Eraser edits continue using incremental repair only when the mask changes.

* **Bug Fixes**
  * Improved handling of overlapping strokes, stale results, and repairs outside the active mask.

* **Documentation**
  * Updated English and Chinese editor documentation for brush repair and undo/redo behavior.

* **Tests**
  * Added regression coverage for forced repairs, revision handling, and undo/redo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->