### PR TITLE
fix(qt-ui): translate_text 传给 dispatch 的是已改名的 translator_config，必定 TypeError

### DIFF
--- a/desktop_qt_ui/services/translation_service.py
+++ b/desktop_qt_ui/services/translation_service.py
@@ -128,7 +128,7 @@ class TranslationService:
             translated_texts = await dispatch_translator(
                 chain,
                 queries,
-                translator_config=config,
+                config=config if config is not None else self.config_service.get_config(),
                 args=ctx
             )
 


### PR DESCRIPTION
## 问题

`TranslationService.translate_text()`（`desktop_qt_ui/services/translation_service.py:128`）调用翻译分发器时用的是 `translator_config=`：

```python
translated_texts = await dispatch_translator(
    chain,
    queries,
    translator_config=config,   # <-- dispatch() 没有这个参数
    args=ctx
)
```

但 `manga_translator/translators/__init__.py:51` 的签名是：

```python
async def dispatch(chain: TranslatorChain, queries: List[str], config: Config,
                   use_mtpe: bool = False, args: Optional[Context] = None,
                   device: str = 'cpu') -> List[str]:
```

所以这个调用必定抛 `TypeError`（缺少必填的 `config`，同时多出未知关键字 `translator_config`），`translate_text()` 走不通。

同一个文件里的兄弟方法 `translate_text_batch()`（`:213`）已经用的是正确写法：

```python
translated_texts = await dispatch_translator(
    chain, texts,
    config=final_config,   # final_config = self.config_service.get_config()
    use_mtpe=False, args=translator_args,
    device='cuda' if final_config.cli.use_gpu else 'cpu'
)
```

`manga_translator/manga_translator.py:5653` 的重译路径同样是按位置传 `config.translator`。只有 `translate_text()` 还留着改名前的 `translator_config=`。

## 修法

改成 `config=`，并在调用方没给 config 时回落到配置服务（与 `translate_text_batch()` 取 `final_config` 的做法一致）：

```python
config=config if config is not None else self.config_service.get_config(),
```

`dispatch()` 内部走 `translator.parse_args(config)` → `_resolve_translator_config()`，它对完整 `Config`（取 `.translator`）和直接传入的 `TranslatorConfig` 都兼容，所以调用方原本传 `TranslatorConfig` 的用法不受影响。

## 验证

从上游 AST 重建 `dispatch()` 的真实签名，用 `inspect.Signature.bind` 回放两个调用点：

```
manga_translator/translators/__init__.py:51  dispatch(chain, queries, config, use_mtpe=…, args=…, device=…)

  translate_text (line 128, current)           -> TypeError: missing a required argument: 'config'
  translate_text_batch (line 213, current)     -> binds OK
  translate_text (line 128, PATCHED)           -> binds OK
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation reliability by ensuring the translator consistently receives the current configuration when processing text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->