### PR TITLE
fix(mask_refinement): complete_mask_fill 少传 mask_shape，非 fit_text 分支必定 TypeError

### DIFF
--- a/manga_translator/mask_refinement/__init__.py
+++ b/manga_translator/mask_refinement/__init__.py
@@ -208,7 +208,7 @@ async def dispatch(
             q = Quadrilateral(l * scale_factor, '', 0)
             textlines.append(q)
 
-    final_mask = complete_mask(img_resized, mask_resized, textlines, dilation_offset=dilation_offset,kernel_size=kernel_size) if method == 'fit_text' else complete_mask_fill([txtln.aabb.xywh for txtln in textlines])
+    final_mask = complete_mask(img_resized, mask_resized, textlines, dilation_offset=dilation_offset,kernel_size=kernel_size) if method == 'fit_text' else complete_mask_fill([txtln.aabb.xywh for txtln in textlines], mask_resized.shape[:2])
     if final_mask is None:
         final_mask = np.zeros((raw_image.shape[0], raw_image.shape[1]), dtype = np.uint8)
     else:


### PR DESCRIPTION
## 问题

`manga_translator/mask_refinement/__init__.py:211`：

```python
final_mask = complete_mask(...) if method == 'fit_text' else complete_mask_fill([txtln.aabb.xywh for txtln in textlines])
```

但 `complete_mask_fill` 的签名是两个参数（`text_mask_utils.py:73`）：

```python
def complete_mask_fill(text_lines: List[Tuple[int, int, int, int]], mask_shape):
    final_mask = np.zeros(mask_shape, dtype=np.uint8)
    ...
```

调用点只传了 1 个位置参数，所以 `dispatch(..., method=<非 'fit_text'>)` 这条分支**必定**抛：

```
TypeError: complete_mask_fill() missing 1 required positional argument: 'mask_shape'
```

## 为什么会漏

对比上游 `zyddnys/manga-image-translator`，那边的 `complete_mask_fill(text_lines)` 只有一个参数，**且函数体本身是坏的**——`final_mask` 在第一次 `cv2.rectangle(final_mask, ...)` 之前从未赋值，会 `UnboundLocalError`。本仓库补了 `final_mask = np.zeros(mask_shape, dtype=np.uint8)` 把这个 bug 修掉了（两份副本 `mask_refinement/text_mask_utils.py:73` 和 `mode/__init__.py:72` 都改了），但唯一的调用点没跟着更新，于是把 `UnboundLocalError` 换成了 `TypeError`。

## 修复

传 `mask_resized.shape[:2]`：

- `textlines` 里的坐标是 `Quadrilateral(l * scale_factor, ...)`，本来就在 resize 后的坐标系里，和 `mask_resized` 同一个空间；
- `fit_text` 分支的 `complete_mask()` 返回的也是 `mask` 尺寸的 2D mask，两条分支形状保持一致；
- 调用点随后的 `cv2.resize(final_mask, (raw_image.shape[1], raw_image.shape[0]))` 会把它还原回原图尺寸，行为不变。

## 验证

用 AST 从源文件里抠出真实的 `complete_mask_fill` 定义 + 真实调用点，`inspect.signature().bind()` 重放：

```
callsite line 211  nargs=1  kwargs=[]
  BIND FAILS -> TypeError: missing a required argument: 'mask_shape'
```

再按 `dispatch()` 的实际计算复刻一遍（900x600 原图 → `scale_factor=0.667` → `mask_resized.shape=(600, 400)`）：

| | 结果 |
|---|---|
| 打补丁前 | `TypeError: complete_mask_fill() missing 1 required positional argument: 'mask_shape'` |
| 打补丁后 | mask `shape=(600, 400)`, `dtype=uint8`，两个矩形填充像素数 `16402`，与手算 `101*41 + 201*61` 完全一致 |
| 下游 resize 回原图 | `(900, 600)`，与 `raw_mask.shape` 相符 |

改动 1 行。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mask filling for translated manga text to ensure operations use the resized mask dimensions, helping produce more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->